### PR TITLE
Update src/caller-of.js

### DIFF
--- a/src/caller-of.js
+++ b/src/caller-of.js
@@ -1,2 +1,2 @@
 // (C) WebReflection, Mit Style License
-function callerOf(c) {'use strict'; return c.bind.call(c.call, c); }
+function callerOf(c) {'use strict'; return c.bind.apply(c.call, arguments); }


### PR DESCRIPTION
why to give up on all of the bind method benefits?
and also it is more readable. 
